### PR TITLE
Fix next page link and show if no infinite scroll

### DIFF
--- a/page-news.php
+++ b/page-news.php
@@ -21,10 +21,12 @@ require(dirname(__FILE__).'/../../../contribook/main/contribook/lib_contribook.p
         echo('<div id="container" class="transitions-enabled infinite-scroll clearfix">');
         CONTRIBOOK_BLOG::show(($page-1)*5,5);
         echo('</div>');
-
+        
+        // If not on ssl, show the page link
+        $ssl = is_ssl() ? '' : 'style="display: block !important; margin-bottom: 60px;"';
         echo('
-        <nav id="page-nav">
-          <a href="/news/2/"></a>
+        <nav id="page-nav" '.$ssl.'>
+          <a href="/news/'.($page+1).'" style="float: right">Next Page</a>
         </nav>
         ');
 


### PR DESCRIPTION
- Shows the 'Next Page' link on the news page if infinite scroll is not working (should not be required if Roman can enable SSL by default)
- Makes the 'Next Page' link actually go to the next page, not just /2 :)

@jospoortvliet 
