### PR TITLE
add a link to third party apps integrating in oc.

### DIFF
--- a/page-homepage.php
+++ b/page-homepage.php
@@ -68,6 +68,7 @@
 							<img id="sync-button" alt="googleplay" src="<?php echo get_template_directory_uri(); ?>/assets/img/clients/buttons/googleplay.png" />
 						</a>
 					  </li>
+						Find <a href="https://github.com/owncloud/core/wiki/Apps">third party apps integrating in ownCloud here</a>.
 					</ul>
 			</div>
 		</div>


### PR DESCRIPTION
 That page needs improvements - I plan on working on it during the conference. @tomneedham @kelleybrooks @MariekevC what do you think, is this OK? Screenshot:
![oc documents2](https://cloud.githubusercontent.com/assets/551757/3909224/5b6fabca-230b-11e4-831b-c87524df8ce4.png)

(new is the link to third-party apps integrating in ownCloud)
