### PR TITLE
fix link element of rss feed

### DIFF
--- a/blogrss.php
+++ b/blogrss.php
@@ -8,7 +8,7 @@ Template Name: Blog Planet RSS Page
 
 require('/srv/www/owncloud.org/contribook/main/contribook/lib_contribook.php');
 
-CONTRIBOOK_BLOG::showrss('ownCloud Planet','The ownCloud blog planet with posts from all ownCloud contributors','http://owncloud.org/planet/rss-feed',30);
+CONTRIBOOK_BLOG::showrss('ownCloud Planet','The ownCloud blog planet with posts from all ownCloud contributors','http://owncloud.org/news/',30);
 
 
 


### PR DESCRIPTION
The link element should point to the website corresponding to the channel
