### PR TITLE
some feature page fixes

### DIFF
--- a/page-features.php
+++ b/page-features.php
@@ -18,8 +18,7 @@
 			<div class="col-md-4 featureblock">
 				<i class="icon-globe"></i>
 				<h3 class="ft-title">Access Your Data</h3>
-				<p class="featuredesc">Store your files, folders, contacts, photo galleries, calendars and more on a server of your choosing. Access that folder from your mobile device,
-				your desktop, or a web browser. Access your data wherever you are, when you need it.</p>
+				<p class="featuredesc">Store your files, folders, contacts, photo galleries, calendars and more on a server of your choosing. Access them from your mobile device, your desktop, or a web browser. Access your data wherever you are, when you need it.</p>
 			</div>
 			<div class="col-md-4 featureblock">
 				<i class="icon-refresh"></i>
@@ -30,7 +29,7 @@
 			<div class="col-md-4 featureblock">
 				<i class="icon-share-alt"></i>
 				<h3 class="ft-title">Share Your Data</h3>
-				<p class="featuredesc">Share your data with others, and give them access to your latest photo galleries, your calendar, your music, or anything else you want them to see. 
+				<p class="featuredesc">Share your data with others, and give them access to your latest photo galleries, your calendar, your music, or anything else you want them to see. With or without password or time limit.
 				Share it publicly, or privately. It is your data, do what you want with it.</p>
 			</div>
 		</div>


### PR DESCRIPTION
@Kelleybrooks

Let me post the changes here in text. On owncloud.org/features, we have three main points: access, sync and share your data. To the text under sharing I added the bold part below:
Share your data with others, and give them access to your latest photo galleries, your calendar, your music, or anything else you want them to see. With or without password or time limit. **Share it publicly, or privately.** It is your data, do what you want with it.

When creating a flyer for end users, I noticed this rather important point seemed missing. And as this point was a bit shorter than the others, this addition actually makes it about equally long, easing layouting too ;-) What do you think?

The second is about the wording of Access. Even more minor, see the bold part for the change:
Store your files, folders, contacts, photo galleries, calendars and more on a server of your choosing. Access **that folder** from your mobile device, your desktop, or a web browser. Access your data wherever you are, when you need it.

Store your files, folders, contacts, photo galleries, calendars and more on a server of your choosing. Access **them** from your mobile device, your desktop, or a web browser. Access your data wherever you are, when you need it.

Maybe it's my non-native speaking skills, but for me this seems that 'that folder' was limiting the list of items?

Third is again about making clear what ownCloud does in a few points. I missed the hosting on our front page... This is under the 'protect' point.
ownCloud gives you control over your data. You decide what is shared with who and for how long.
ownCloud gives you control over your data. You decide **where your data is,** what is shared with who and for how long.
The bold part is new, again. What do you think?
