### PR TITLE
add that the list isn't complete, see github

### DIFF
--- a/page-contact.php
+++ b/page-contact.php
@@ -33,4 +33,6 @@ if(CONTRIBOOK) {
 
 }
 ?>
-Ping the community manager  on IRC (nick: jospoortvliet) or <a href="https://plus.google.com/117563705675081959469">G+</a>.
+Note that, unfortunately, most of our contributors have not (yet) set up a blog and and added themselves here. You can find a much more complete list of past and present ownCloud contributors on <a href="https://github.com/orgs/owncloud/people">github</a>, which is where we develop ownCloud.
+
+If you want to be added to the blog roll, please ping the ownCloud community manager on IRC (nick: jospoortvliet) or via <a href="https://plus.google.com/117563705675081959469">G+</a>, <a href="https://twitter.com/jospoortvliet">twitter</a> or <a href="https://pod.geraspora.de/u/jospoortvliet">diaspora</a>.


### PR DESCRIPTION
small fix... owncloud.org/contact links now to github/org/owncloud/people