### PR TITLE
Privacy

### DIFF
--- a/page-news.php
+++ b/page-news.php
@@ -6,6 +6,7 @@ require(dirname(__FILE__).'/../../../contribook/main/contribook/lib_contribook.p
   <div class="col-sm-12">
     <h1>ownCloud Planet</h1>
     <a href="/blogfeed" class="rss-button"><img style="vertical-align: top;" width=35 class="img-circle" src="<?php echo get_template_directory_uri(); ?>/assets/img/social/rss.png"></img></a>
+    <p>Welcome to ownCloud News, our contributor blog roll. ownCloud contributors should <a href="https://mailman.owncloud.org/pipermail/devel/2014-April/000123.html">ask to get added</a>! We are not responsible for content here, see our <a href="/privacy">privacy policy</a>.</p>
   </div>
 </div>
 

--- a/page-newsletter.php
+++ b/page-newsletter.php
@@ -10,5 +10,6 @@
 		</div>
 	</div>
 </div>
+<p>We promise not to share your email address with anybody else. See our <a href="/privacy">privacy policy</a> for details.</p>
 <p>To follow ownCloud in more 'real-time' fashion, you can also subscribe to our news feed on <a href="/news">owncloud.org/news</a>.</p>
 

--- a/page-privacy.php
+++ b/page-privacy.php
@@ -3,6 +3,10 @@
         <div class="page-header">
             <h1>Privacy Policy</h1>
         </div>
-        <p>We recognize that privacy is extremely important to our users. We do not share individual user data with third parties without your permission. We use our own install of <a href="http://piwik.org/">Piwik</a> and, sometimes, other third-party analytics services on our web sites to understand how people use our web pages. Our news letter is handled via Constant Contact, see their <a href="http://www.constantcontact.com/legal/privacy-statement">privacy policy</a>. Registration for ownCloud events is handled by websites we deploy and manage ourselves. If we experience a privacy breach, we promise to disclose it as soon as possible. If you spot a privacy leak, please report it discreetly to <a href="mailto:info@owncloud.com">info@owncloud.com</a>.</p>
+        <p>We recognize that privacy is extremely important to our users. We do not share individual user data with third parties without your permission.</p>
+        <p>We use our own install of <a href="http://piwik.org/">Piwik</a> and, sometimes, other third-party analytics services on our web sites to understand how people use our web pages. Our news letter is handled via Constant Contact, see their <a href="http://www.constantcontact.com/legal/privacy-statement">privacy policy</a>. Registration for ownCloud events is handled by websites we deploy and manage ourselves. If we experience a privacy breach, we promise to disclose it as soon as possible.</p>
+        <p>Note that content on <a href="/news">owncloud.org/news</a> is aggregated from community blogs and we are not responsible for their opinions or content.</p>
+        <p>If you spot a privacy leak or see anything unseemly on our website, please report it discreetly to <a href="mailto:abuse@owncloud.com">abuse@owncloud.com</a>.</p>
+        <p>ownCloud.org is run by <a href="https://owncloud.com">ownCloud</a>, 57 Bedford St, Suite 102, Lexington  MA 02420</p>
         </div>
 </div>

--- a/templates/footer.php
+++ b/templates/footer.php
@@ -49,7 +49,7 @@
    </div>
    <div class="row">
     <div class="col-lg-12 footer-text">
-      <p><font face="sans"> &copy; </font> <?php echo date('Y'); ?> ownCloud.org</p>
+      <p><font face="sans"> &copy; </font> <?php echo date('Y'); ?> ownCloud</p>
   </div>
 </div>
 </footer>


### PR DESCRIPTION
- changing footer to "copyright ownCloud" (without .org)
- adding mail address to mail for abuse to privacy page
- adding ownCloud Inc info to privacy page
- adding link to privacy page on news and newsletter pages

@karlitschek as just agreed in the call