### PR TITLE
Change www repo to owncloud.org repo

### DIFF
--- a/404.php
+++ b/404.php
@@ -5,7 +5,7 @@
 </div>
 <div class="row">
 	<div class="span12">
-		<p>We've recently reorganised the website and some old links may no longer be working correctly. If you think there is an issue within our website, please report it using the <a href="https://github.com/owncloud/www/issues/new" target="_blank">issue tracker</a> or <a href="https://github.com/owncloud/www/blob/master/README.md" target="_blank">submit a patch</a>. Please try searching for the page you are looking for:</p>
+		<p>We've recently reorganised the website and some old links may no longer be working correctly. If you think there is an issue within our website, please report it using the <a href="https://github.com/owncloud/owncloud.org/issues/new" target="_blank">issue tracker</a> or <a href="https://github.com/owncloud/owncloud.org/blob/master/README.md" target="_blank">submit a patch</a>. Please try searching for the page you are looking for:</p>
 	</div>
 </div>
 


### PR DESCRIPTION
https://github.com/owncloud/www/issues redirects to https://github.com/owncloud/owncloud.org/issues but it still worth to have the direct link in there.