### PR TITLE
"Sync your data" - Text Design Improvements

### DIFF
--- a/page-install.php
+++ b/page-install.php
@@ -18,7 +18,7 @@
     <hr class="narrow"></hr>
     <div class="numbadge centre">2</div>
     <h3><i class="icon-refresh"></i> Sync your data</h3>
-    <p>Connect to your ownCloud with our clients:</p>
+    <p>Connect to your ownCloud with our clients for your devices:</p>
     <div class="btn-group">
       <a class="btn btn-default btn-lg" role="button" href="#install-clients" rel="tooltip" id="desktop" data-toggle="popover" title="Desktop Clients">Desktop Clients</a>
       <a class="btn btn-default btn-lg" role="button" href="#install-clients" rel="tooltip" id="mobile" data-toggle="popover" title="Mobile Clients">Mobile clients</a>


### PR DESCRIPTION
Make the text under "Sync your data" longer, so that the text has 2 columns like "Download ownCloud Server" and "Extend your Cloud" and the buttons are on the same level.

<img width="757" alt="bild" src="https://cloud.githubusercontent.com/assets/12893462/13637043/7b182790-e605-11e5-99a8-c792dd97a34d.png">
