### PR TITLE
"Get" instead of "Download"

### DIFF
--- a/page-install.php
+++ b/page-install.php
@@ -6,7 +6,7 @@
   <div class="col-md-4">
     <hr class="narrow"></hr>
     <div class="numbadge centre">1</div>
-    <h3><i class="icon-download"></i> Download ownCloud Server</h3>
+    <h3><i class="icon-download"></i> Get ownCloud Server</h3>
     <p>Set up a server yourself, deploy to the cloud or find a provider:</p>
     <div class="btn-group">
       <a class="btn btn-default btn-lg" role="button" href="#instructions-server" rel="tooltip" title="Install instructions" id="server" data-toggle="popover">Download</a>


### PR DESCRIPTION
You are not always "downloading" ownCloud Server. If you click on "Providers" - then you "get" an ownCloud Server, but you are not "downloading" it :wink: 