### PR TITLE
added link to owncloud/documentation for distinction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Contributing to ownCloud.org website
 
 Please take a moment to review this document in order to make the contribution
-process easy and effective for everyone involved.
+process easy and effective for everyone involved.    
+https://doc.ownCloud.org is not maintained here, but in https://github.com/owncloud/documentation
 
 ## Setup of a local development environment
 


### PR DESCRIPTION
Added reference to owncloud/documentation to make it easier for people that want to contribute to the doc.owncloud.org part of owncloud.org.