### PR TITLE
Fix broken links

### DIFF
--- a/page-changelog.php
+++ b/page-changelog.php
@@ -924,11 +924,11 @@ Packages on the openSUSE Build Service: <a href="http://software.opensuse.org/do
 
 <h3>Version 8.0.11 <small>March 8 2016</small></h3>
 <ul>
-	<li>Prevent 0 byte downloads when storage returns false - <a href="http://github.com/owncloud/core/issues/19081">github issue</a></li>
-	<li>Keep scroll position in user's page when sorting - <a href="http://github.com/owncloud/core/issues/21634">github issue</a></li>
-	<li>Always use an LDAP URL when connecting to LDAP - <a href="http://github.com/owncloud/core/issues/21634">github issue</a></li>
-	<li>Shares moving back to default "landing" dir - <a href="http://github.com/owncloud/core/issues/12385">github issue</a></li>
-	<li>PHPMailer address validation fix - <a href="http://github.com/owncloud/3rdparty/issues/253">github issue</a></li>
+	<li>Prevent 0 byte downloads when storage returns false - <a href="https://github.com/owncloud/core/issues/19081">github issue</a></li>
+	<li>Keep scroll position in user's page when sorting - <a href="https://github.com/owncloud/core/issues/21634">github issue</a></li>
+	<li>Always use an LDAP URL when connecting to LDAP - <a href="https://github.com/owncloud/core/issues/21634">github issue</a></li>
+	<li>Shares moving back to default "landing" dir - <a href="https://github.com/owncloud/core/issues/12385">github issue</a></li>
+	<li>PHPMailer address validation fix - <a href="https://github.com/owncloud/3rdparty/issues/253">github issue</a></li>
 </ul>
 Download: <a href="https://download.owncloud.org/community/owncloud-8.0.11.tar.bz2">owncloud-8.0.11.tar.bz2</a> or <a href="https://download.owncloud.org/community/owncloud-8.0.11.zip">owncloud-8.0.11.zip</a></br>
 MD5: <a href="https://download.owncloud.org/community/owncloud-8.0.11.tar.bz2.md5">owncloud-8.0.11.tar.bz2.md5</a> or <a href="https://download.owncloud.org/community/owncloud-8.0.11.zip.md5">owncloud-8.0.11.zip.md5</a></br>
@@ -938,7 +938,7 @@ Packages on the openSUSE Build Service: <a href="http://software.opensuse.org/do
 
 <h3>Version 7.0.13 <small>March 8 2016</small></h3>
 <ul>
-<li>PHPMailer address validation - <a href="http://github.com/owncloud/3rdparty/issues/253">github issue</a></li>
+<li>PHPMailer address validation - <a href="https://github.com/owncloud/3rdparty/issues/253">github issue</a></li>
 </ul>
 Download: <a href="https://download.owncloud.org/community/owncloud-7.0.13.tar.bz2">owncloud-7.0.13.tar.bz2</a> or <a href="https://download.owncloud.org/community/owncloud-7.0.13.zip">owncloud-7.0.13.zip</a></br>
 MD5: <a href="https://download.owncloud.org/community/owncloud-7.0.13.tar.bz2.md5">owncloud-7.0.13.tar.bz2.md5</a> or <a href="https://download.owncloud.org/community/owncloud-7.0.13.zip.md5">owncloud-7.0.13.zip.md5</a></br>

--- a/page-contribute.php
+++ b/page-contribute.php
@@ -44,7 +44,7 @@ Do you want to <strong>help</strong> translate, promote or document ownCloud?</p
             <h3><i class="icon-refresh"></i>&nbsp;&nbsp;Test ownCloud</h3>
             <p>Testing upcoming ownCloud Server releases is the best way of making sure the new release can do what you need it 
             to do. And of course, only if you report a problem to us we know about it and can fix it! If you have a bug to report,
-            find the <a href="https://github.com/owncloud/core/blob/master/CONTRIBUTING.md">issue submission guidelines here</a>.</p>
+            find the <a href="https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md">issue submission guidelines here</a>.</p>
             <p>Anybody interested in helping out with ownCloud Server testing is invited to join the ownCloud Test Pilot team.
             See <a href="<?php echo $DOCUMENTATION_DEVELOPER; ?>testing">the Test Pilot documentation</a> for information!.</p>
 	</div>

--- a/page-meetups.php
+++ b/page-meetups.php
@@ -39,7 +39,7 @@
 		<p>Now you have a place and some participants, but what to do? It is easiest to separate two kinds of Meetups: the one where (potential) ownCloud 
 			contributors come together; and one where users meet up.</p>
 		<p><strong>Development Meetups</strong> need very little: room, wifi, people with laptops. Keep it simple: ownClouders will get along just fine. Open by doing
-			a round of introductions, ask everybody to share what they would like to do. You can use one or more of our <a href="http://github.com/owncloud/promo">ready-made workshop presentations to get started</a> but if everybody just wants to get hacking: that's great!</p>
+			a round of introductions, ask everybody to share what they would like to do. You can use one or more of our <a href="https://github.com/owncloud/promo">ready-made workshop presentations to get started</a> but if everybody just wants to get hacking: that's great!</p>
 
 		<p>Of course, every now and then you could get an interesting speaker to discuss some Cloudy subject.</p>
 	<img src="<?php echo get_template_directory_uri(); ?>/assets/img/events/meetup2.jpg" style="width: 400px" title="pic by Raghu Nayar" alt="pic by Raghu Nayar" class="img-thumbnail alignright">

--- a/page-support.php
+++ b/page-support.php
@@ -38,7 +38,7 @@
 	    <li><a href="irc://#owncloud@freenode.net" target="_blank">the ownCloud IRC chat channel</a> on freenode.net, also accessible via <a href="https://webchat.freenode.net/?channels=owncloud" target="_blank">webchat</a></li>
 	    <li>You can ask over our social media, including in the <a href="https://plus.google.com/communities/101550101068949663712" target="_blank">ownCloud Google Plus community</a>, the <a href="https://www.facebook.com/ownClouders" target="_blank">Facebook page</a> or on <a href="https://twitter.com/search?q=%23owncloud&src=typd" target="_blank">Twitter</a></li>
 	    <li>Check out our documentation wiki page for <a href="https://github.com/owncloud/documentation/wiki">edge cases and rare issues</a></li>
-	    <li>Finally, you could report a issue at our <a href="https://github.com/owncloud/core/blob/master/CONTRIBUTING.md#submitting-issues" target="_blank">bug trackers</a> if you think you found a bug in ownCloud itself</li>
+	    <li>Finally, you could report a issue at our <a href="https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#submitting-issues" target="_blank">bug trackers</a> if you think you found a bug in ownCloud itself</li>
 	</ul>
 	<p>Please understand that all these channels essentially consist of users like you helping each other out. Consider helping others out where you can, to contribute back for the help you get. This is the only way to keep a community like ownCloud healthy and sustainable!</p>
       </td>

--- a/page-trademarks.php
+++ b/page-trademarks.php
@@ -18,7 +18,7 @@
 <p>We acknowledge and support your right to make <em>"fair use"</em> of the ownCloud Marks, and do not mean to suggest with these guidelines that our permission is required in such cases. We cannot, however, tell you categorically what will and will not qualify as a "fair use."</p>
 
 <h3>Applying our Logo</h3>
-<p>For copies of the ownCloud logo itself, please refer to the <a href="http://github.com/owncloud/promo" target="_blank">promo GitHub page</a>. There you find also additional guidance about modifications you should avoid and how to integrate the logo in artwork or a website.</p>
+<p>For copies of the ownCloud logo itself, please refer to the <a href="https://github.com/owncloud/promo" target="_blank">promo GitHub page</a>. There you find also additional guidance about modifications you should avoid and how to integrate the logo in artwork or a website.</p>
 
 <h3>Logo Usage Requirements</h3>
 <p>Do not alter the logo in any way or overlap it with additional logos or images.</p>


### PR DESCRIPTION
The CONTRIBUTING.md links got broken with https://github.com/owncloud/core/pull/25937 and updated in core / documentation with https://github.com/owncloud/core/pull/26087 and https://github.com/owncloud/documentation/pull/2618.

There are also a few links pointing to http://github.com/* instead of https://github.com which i have updated also.