### PR TITLE
removed arvixe from providers

### DIFF
--- a/assets/providers.json
+++ b/assets/providers.json
@@ -1,20 +1,6 @@
 {
    "providers":[
       {
-         "title":"arvixe.com",
-         "url":"http:\/\/www.arvixe.com\/owncloud_hosting?utm_campaign=Providers&utm_medium=showcase&utm_source=owncloud.com",
-         "freeurl":"http:\/\/www.arvixe.com\/owncloud-trial?utm_campaign=Free&utm_medium=showcase&utm_source=owncloud.com",
-         "flags":[
-            "gb"
-         ],
-         "freeplans":false,
-         "supports":[
-            "consumers"
-         ],
-         "imagename":"arvixe.png",
-         "supported":true
-      },
-      {
          "title":"vboxx.nl",
          "url":"http:\/\/vboxx.nl\/",
          "flags":[


### PR DESCRIPTION
arvixe doesn't seem to provide owncloud anymore.
Also there have been complaints...
https://forum.owncloud.org/viewtopic.php?t=36685

There seems no owncloud available from arvixe anymore.... i will investigate for owncloud.com also if business is dropped.
