### PR TITLE
Fix ooredoo provider link

### DIFF
--- a/assets/providers.json
+++ b/assets/providers.json
@@ -1515,7 +1515,7 @@
       },
       {
          "title":"Ooredoo",
-         "url":"http:\/\/http://www.ooredoo.dz/\/",
+         "url":"http:\/\/www.ooredoo.dz\/",
          "flags":[
             "dz"
          ],


### PR DESCRIPTION
As reported by a user in IRC. Currently the link is broken like seen on:

https://owncloud.org/providers/

and looks like:

``http://http//www.ooredoo.dz//``