### PR TITLE
Add unsupported text to 8.1 link

### DIFF
--- a/page-changelog.php
+++ b/page-changelog.php
@@ -7,7 +7,7 @@ Go directly to the latest maintenance release of:
 <li><a href="#latest9.1">ownCloud 9.1</a></li>
 <li><a href="#latest9.0">ownCloud 9.0</a></li>
 <li><a href="#latest8.2">ownCloud 8.2</a></li>
-<li><a href="#latest8.1">ownCloud 8.1</a></li>
+<li><a href="#latest8.1">ownCloud 8.1 (unsupported!)</a></li>
 <li><a href="#latest8.0">ownCloud 8.0 (unsupported!)</a></li>
 <li><a href="#latest7">ownCloud 7 (unsupported!)</a></li>
 <li><a href="#latest6">ownCloud 6 (unsupported!)</a></li>


### PR DESCRIPTION
8.1 is EOL since February: https://github.com/owncloud/core/wiki/Maintenance-and-Release-Schedule