### PR TITLE
Workaround for broken link.

### DIFF
--- a/page-events-archive.php
+++ b/page-events-archive.php
@@ -8,7 +8,7 @@
 <div class="row">
 	<div class="col-md-12">
 		<h2>Event Archive</h2>
-		<p>This is our event archive. Here you can find the events where we participated in the last years, beginning from 2015. For current events, take a look at our <a target="_blank" href="page-events.php">events page</a>.</p>
+		<p>This is our event archive. Here you can find the events where we participated in the last years, beginning from 2015. For current events, take a look at our <a target="_blank" href="/events/">events page</a>.</p>
 
 		<h3>Events we've been at in 2016</h3>
 		<table class="table table-striped">

--- a/page-events-archive.php
+++ b/page-events-archive.php
@@ -1,9 +1,5 @@
-<?php get_template_part('templates/parts/title'); ?>
-<div class="sub-nav">
-	<!-- a href="/events/meetups">Meetups</a>&nbsp;&nbsp;
-	|&nbsp;&nbsp; -->
-	<a href="/events/conference-program">Conference Program</a>
-	|&nbsp;&nbsp;<a href="/events/contactform">Contact</a>
+<div class="page-header">
+	<h1><a href="/events">Events</a> > Archive</h1>
 </div>
 <div class="row">
 	<div class="col-md-12">

--- a/page-events.php
+++ b/page-events.php
@@ -177,9 +177,10 @@
 			</tr>
 		</table>
 		
-
+<!-- Link is broken. Include this as soon as it is fixed
 		<h3>Events before 2017</h3>
 		<p>For events before 2017, please take a look into our <a target="_blank" href="page-events-archive.php">Event Archive</a>.</p>
+--!>
 
 <!--		<h2>Release parties</h2>
 		<p>One of the best parts of an ownCloud release, are the community release parties! A release party can be a meeting in a cafe or office with a


### PR DESCRIPTION
The link is commented out for now, and the content in page-events-archive.php not reachable. If someone helps me setting up my testing environment on lefherz.kaus.uberspace.de, or tells me how page-asdf.php are generated to an owncloud.org/asdf/ URL, we can figure this out in the long term. Until then, take this bad workaround.
Sry for spamming pull requests, forgot to merge my own clone before pushing