### PR TITLE
Couldn't switch tabs correctly before

### DIFF
--- a/install-instructions.php
+++ b/install-instructions.php
@@ -269,8 +269,7 @@
 			<div class="row">
 				<a href="#" class="close">&times;</a>
 				<ul class="nav nav-tabs" role="tablist">
-					<li id="li-tab-
-                  " class="active"><a href="#tab-desktop" class="btn btn-lg" title="Install Desktop Clients" role="tab" data-toggle="tab"><i class="icon-archive"></i> Install Desktop Clients</a></li>
+					<li id="li-tab-desktop" class="active"><a href="#tab-desktop" class="btn btn-lg" title="Install Desktop Clients" role="tab" data-toggle="tab"><i class="icon-archive"></i> Install Desktop Clients</a></li>
 					<li id="li-tab-mobile"><a href="#tab-mobile" class="btn btn-lg" title="Install Mobile Apps" role="tab" data-toggle="tab"><i class="icon-code"></i> Install Mobile Apps</a></li>
 				</ul>
 			</div>


### PR DESCRIPTION
I hope this solves following problem:

original Bug report (via mail):  
On the https://owncloud.org/install/ page, if you click on the "Mobile client", you can not go to the "install desktop client" tab. I checked on windows 10 google chrome and Edge.