### PR TITLE
Fix for some tabchanging

### DIFF
--- a/install-instructions.php
+++ b/install-instructions.php
@@ -269,8 +269,7 @@
 			<div class="row">
 				<a href="#" class="close">&times;</a>
 				<ul class="nav nav-tabs" role="tablist">
-					<li id="li-tab-
-                  " class="active"><a href="#tab-desktop" class="btn btn-lg" title="Install Desktop Clients" role="tab" data-toggle="tab"><i class="icon-archive"></i> Install Desktop Clients</a></li>
+					<li id="li-tab-desktop" class="active"><a href="#tab-desktop" class="btn btn-lg" title="Install Desktop Clients" role="tab" data-toggle="tab"><i class="icon-archive"></i> Install Desktop Clients</a></li>
 					<li id="li-tab-mobile"><a href="#tab-mobile" class="btn btn-lg" title="Install Mobile Apps" role="tab" data-toggle="tab"><i class="icon-code"></i> Install Mobile Apps</a></li>
 				</ul>
 			</div>

--- a/install-instructions.php
+++ b/install-instructions.php
@@ -146,7 +146,7 @@
 								<p>You can find further instructions in the <a href="<?php echo $DOCUMENTATION_ADMIN; ?>installation">ownCloud Admin Manual</a>. If you already run ownCloud, refer to the <a href="<?php echo $DOCUMENTATION_ADMIN; ?>maintenance/upgrade.html">upgrade manual</a for moving to new ownCloud releases.</p>
 							</div>
 							<div class="col-sm-5 button-area">
-								<h3>Latest stable version<!--: <strong><?php echo $VERSIONS_SERVER_FULL_STABLE; ?></strong>--></h3>
+								<h3>Latest stable version: <strong><?php echo $VERSIONS_SERVER_PACKAGES_STABLE; ?></strong></h3>
 								<h4><strong><a class="changelog" href="/changelog">See what's new (Changelog)</a></strong></h4>
 								<a href="<?php echo $DOWNLOAD_SERVER_PACKAGES_STABLE; ?>" class="button blue primary">Continue to the Packages</a>
 								<p class="mt30">Want to use ownCloud for your Company?</p>
@@ -230,7 +230,7 @@
 
 								</div>
 								<div class="col-sm-5 button-area">
-									<h3>Latest stable version: <strong><?php echo $VERSIONS_SERVER_FULL_STABLE; ?></strong></h3>
+									<h3>Latest stable version: <strong><?php echo $VERSIONS_SERVER_APPLIANCE_STABLE; ?></strong></h3>
 									<h4><strong><a class="changelog mb0" href="/changelog">See what's new (Changelog)</a></strong></h4>
 									<h5 class="mb15">Grab the official ownCloud virtual machine image in one of these formats:</h5>
 									<a href="<?php echo $DOWNLOAD_VM_ESX_OVA; ?>" class="button blue secondary">ESX</a>
@@ -249,7 +249,6 @@
 									<a href="https://owncloud.com/download/?ref=orgB" target="_blank" class="button orange primary mb30">Test Enterprise Edition free for 30 days</a>
 									<hr />
 									<div class="download-notes">
- 										<p><strong>NOTE</strong>: The appliances have been updated to <a href="https://owncloud.org/blog/introducing-owncloud-x/">ownCloud 10.0</a> but have only gone through absolutely minimal testing. It is recommended to not use these for important data yet - giving them a trial run however and giving us feedback is greatly appreciated!</p>
 										<p><strong>Security Note:</strong><br />These images do not all offer automatic update technology. We recommend a subscription to our low-traffic <a href="https://mailman.owncloud.org/mailman/listinfo/announcements">announcement mailing list</a> for notifications on updates and security issues. Find here the public ownCloud <a href="<?php echo $OWNCLOUD_GPG; ?>">GPG key</a>.</p>
 										<p><strong>Channels:</strong><br />We offer <a href="/release-channels">Release Channels</a> to track specific branches like Beta's or older stable branches. Find <a href="/install/#testing-development">development packages</a> for testing here.</p>
 									</div>

--- a/strings.php
+++ b/strings.php
@@ -8,6 +8,8 @@ $VERSIONS_SERVER_MAJOR_DEVELOPMENT = '10.0';
 $VERSIONS_SERVER_MAJOR_DEV_DOCS = '10.0'; // Used in dev docs links
 $VERSIONS_CLIENT_DESKTOP_STABLE_FULL = '2.3.2';
 $VERSIONS_CLIENT_DESKTOP_STABLE_SHORT = '2.3'; // For use in documentation link
+$VERSIONS_SERVER_APPLIANCE_STABLE = '10.0.1'; // only as long as the versions differ, used only in install-instructions.php
+$VERSIONS_SERVER_PACKAGES_STABLE = '9.1.6'; // only as long as the versions differ, used only in install-instructions.php
 
 /* DOCUMENTATION */
 $DOCUMENTATION_BASE = 'https://doc.owncloud.org';


### PR DESCRIPTION
This solves following problem:

original Bug report (via mail):
On the https://owncloud.org/install/ page, if you click on the "Mobile client", you can not go to the "install desktop client" tab. I checked on windows 10 google chrome and Edge.

I tested it on staging, it's fine.