### PR TITLE
Revert "added paragraph about the android beta client, to review"

### DIFF
--- a/install-instructions.php
+++ b/install-instructions.php
@@ -388,8 +388,6 @@
 		      <a href="<?php echo $DOWNLOAD_CLIENT_DESKTOP_TEST_SOURCES; ?>" class="btn btn-lg btn-default"><i class="icon-archive"></i> Sources</a>
 		    </div>
 		    <?php } ?>
-                    <h2>Android Clients <small><?php echo $VERSIONS_CLIENT_ANDROID_TESTING; ?></small></h2>
-                    <p>Our mobile team provides regular pre-releases. You can install them from the <a href="https://f-droid.org/packages/com.owncloud.android.beta/" target="_blank">F-Droid Android Appstore</a>. Please report any issues to the <a href="https://github.com/owncloud/android/issues" target="_blank">tracker</a>.</p>
 		  </div>
 		</div>
 		<div class="overlay-body row">

--- a/strings.php
+++ b/strings.php
@@ -48,9 +48,6 @@ $DOWNLOAD_CLIENT_DESKTOP_TEST_SOURCES= $DOWNLOAD_CLIENT_DESKTOP_TEST_BASE.'owncl
 // $DOWNLOAD_CLIENT_DESKTOP_TEST_SOURCES = 'https://github.com/owncloud/client/archive/v2.3.3-rc1.tar.gz';
 $DOWNLOAD_CLIENT_DESKTOP_TEST_SOURCES_PGP = $DOWNLOAD_CLIENT_DESKTOP_TEST_SOURCES.'.asc';
 
-// Only used in https://owncloud.org/install/#testing-development
-$VERSIONS_CLIENT_ANDROID_TESTING= '2.5.0-beta.1'
-
 // Server
 $DOWNLOAD_SERVER_BASE = 'https://download.owncloud.org/community/';
 


### PR DESCRIPTION
Reverts owncloud/owncloud.org#1261

staging.owncloud.com broke. I will revert this PR to see if https://github.com/owncloud/owncloud.org/pull/1261 was the reason.