### PR TITLE
prepare client-2.3.3 release

### DIFF
--- a/page-desktop.php
+++ b/page-desktop.php
@@ -27,7 +27,7 @@ Download:
 <a href="https://download.owncloud.com/desktop/stable/testpilotcloud-2.3.3.8243.pkg">Mac</a> |
 <a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> |
 <a href="https://software.opensuse.org/download/package?project=isv:ownCloud:testpilot&amp;package=testpilotcloud-client">Linux</a> |
-<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.3.3.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/testing/owncloudclient-2.3.3-rc2.tar.xz.asc">PGP signature</a>)
+<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.3.3.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.3.3.tar.xz.asc">PGP signature</a>)
 
 
 <h3 id="232">Release 2.3.2 <small>May 8th 2017</small></h3>

--- a/page-desktop.php
+++ b/page-desktop.php
@@ -3,7 +3,7 @@
 </div>
 
 <!-- When doing beta/rc vs release, always check the subdirectory name and the OBS repo name!! //-->
-<h3 id="233">Release 2.3.3 <b>rc2</b> <small>August 18th 2017</small></h3>
+<h3 id="233">Release 2.3.3 <small>August 28th 2017</small></h3>
 <ul>
 	<li>Chunking NG: Don't use old chunking on new DAV endpoint (<a href="https://github.com/owncloud/client/issues/5855">5855</a>)</li>
 	<li>Selective Sync: Skip excluded folders when reading DB, don't let them show errors (<a href="https://github.com/owncloud/client/issues/5772">5772</a>)</li>
@@ -17,12 +17,17 @@
 	<li>Windows: Fix a memory leak in FileSystem::longWinPath</li>
 	<li>Switch Linux build also to Qt 5.6.2 (<a href="https://github.com/owncloud/client/issues/5470">5470</a>)</li>
 	<li>Stopped maintaining Qt 4 buildability</li>
+        <li>Linux packaging fixes: install the owncloud-client-nemo, owncloud-client-nautilus, owncloud-client-caja, owncloud-client-dolphin package for sync-state icons and a share-with menu in your file manager.</li>
+        <li>Linux deprecation: Releases after 2.3.3 do not support Fedora_24 or lower, openSUSE_13.2 or lower, Debian_7.0 or lower.</li>
 </ul>
 Download:
-<a href="https://download.owncloud.com/desktop/testing/ownCloud-2.3.3.8193rc2-setup.exe">Windows</a> |
-<a href="https://download.owncloud.com/desktop/testing/ownCloud-2.3.3.8187rc2.pkg">Mac</a> |
-<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:community:testing&amp;package=owncloud-client">Linux</a> |
-<a href="https://download.owncloud.com/desktop/testing/owncloudclient-2.3.3-rc2.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/testing/owncloudclient-2.3.3-rc2.tar.xz.asc">PGP signature</a>)
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.3.3.8250-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/testpilotcloud-2.3.3.8251-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.3.3.8242.pkg">Mac</a> |
+<a href="https://download.owncloud.com/desktop/stable/testpilotcloud-2.3.3.8243.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> |
+<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:testpilot&amp;package=testpilotcloud-client">Linux</a> |
+<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.3.3.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/testing/owncloudclient-2.3.3-rc2.tar.xz.asc">PGP signature</a>)
 
 
 <h3 id="232">Release 2.3.2 <small>May 8th 2017</small></h3>

--- a/strings.php
+++ b/strings.php
@@ -6,7 +6,7 @@ $VERSIONS_SERVER_MAJOR_STABLE = '10.0';
 $VERSIONS_SERVER_FULL_STABLE = '10.0.2';
 $VERSIONS_SERVER_MAJOR_DEVELOPMENT = '10.0';
 $VERSIONS_SERVER_MAJOR_DEV_DOCS = '10.0'; // Used in dev docs links
-$VERSIONS_CLIENT_DESKTOP_STABLE_FULL = '2.3.2';
+$VERSIONS_CLIENT_DESKTOP_STABLE_FULL = '2.3.3';
 $VERSIONS_CLIENT_DESKTOP_STABLE_SHORT = '2.3'; // For use in documentation link
 $VERSIONS_SERVER_APPLIANCE_STABLE = '10.0.1'; // only as long as the versions differ, used only in install-instructions.php
 $VERSIONS_SERVER_PACKAGES_STABLE = '9.1.6'; // only as long as the versions differ, used only in install-instructions.php
@@ -25,17 +25,16 @@ $OWNCLOUD_GPG = 'https://owncloud.org/owncloud.asc';
 
 // Desktop client stable
 $DOWNLOAD_CLIENT_DESKTOP_BASE = 'https://download.owncloud.com/desktop/stable/';
-$DOWNLOAD_CLIENT_DESKTOP_STABLE_WIN = $DOWNLOAD_CLIENT_DESKTOP_BASE.'ownCloud-2.3.2.6928-setup.exe';
-$DOWNLOAD_CLIENT_DESKTOP_STABLE_MAC = $DOWNLOAD_CLIENT_DESKTOP_BASE.'ownCloud-2.3.2.4250.pkg';
+$DOWNLOAD_CLIENT_DESKTOP_STABLE_WIN = $DOWNLOAD_CLIENT_DESKTOP_BASE.'ownCloud-2.3.3.8250-setup.exe';
+$DOWNLOAD_CLIENT_DESKTOP_STABLE_MAC = $DOWNLOAD_CLIENT_DESKTOP_BASE.'ownCloud-2.3.3.8242.pkg';
 $DOWNLOAD_CLIENT_DESKTOP_STABLE_LINUX = 'https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client';
-$DOWNLOAD_CLIENT_DESKTOP_STABLE_SOURCES = $DOWNLOAD_CLIENT_DESKTOP_BASE.'owncloudclient-2.3.2.tar.xz';
-// The .tar.gz on github and our .tar.xz differ because of submodules etc!
-// $DOWNLOAD_CLIENT_DESKTOP_STABLE_SOURCES = 'https://github.com/owncloud/client/archive/v2.3.3.tar.gz';
+$DOWNLOAD_CLIENT_DESKTOP_STABLE_SOURCES = $DOWNLOAD_CLIENT_DESKTOP_BASE.'owncloudclient-2.3.3.tar.xz';
 $DOWNLOAD_CLIENT_DESKTOP_STABLE_SOURCES_PGP = $DOWNLOAD_CLIENT_DESKTOP_STABLE_SOURCES.'.asc';
 
 // Desktop client testing
 // By having an empty VERSIONS_CLIENT_DESKTOP_TESTING the website should show the nightly links instead
-$VERSIONS_CLIENT_DESKTOP_TESTING = '2.3.3 rc2';
+// $VERSIONS_CLIENT_DESKTOP_TESTING = '2.3.3 rc2';
+$VERSIONS_CLIENT_DESKTOP_TESTING = '';
 $DOWNLOAD_CLIENT_DESKTOP_TEST_BASE= 'https://download.owncloud.com/desktop/testing/';
 $DOWNLOAD_CLIENT_DESKTOP_TEST_WIN = $DOWNLOAD_CLIENT_DESKTOP_TEST_BASE.'ownCloud-2.3.3.8193rc2-setup.exe';
 $DOWNLOAD_CLIENT_DESKTOP_TEST_MAC = $DOWNLOAD_CLIENT_DESKTOP_TEST_BASE.'ownCloud-2.3.3.8187rc2.pkg';
@@ -44,8 +43,6 @@ $DOWNLOAD_CLIENT_DESKTOP_TESTPILOT_WIN = $DOWNLOAD_CLIENT_DESKTOP_TEST_BASE.'tes
 $DOWNLOAD_CLIENT_DESKTOP_TESTPILOT_MAC = $DOWNLOAD_CLIENT_DESKTOP_TEST_BASE.'testpilotcloud-2.3.3.8188rc2.pkg';
 $DOWNLOAD_CLIENT_DESKTOP_TESTPILOT_LINUX = 'https://software.opensuse.org/download/package?project=isv:ownCloud:testpilot:testing&amp;package=testpilotcloud-client';
 $DOWNLOAD_CLIENT_DESKTOP_TEST_SOURCES= $DOWNLOAD_CLIENT_DESKTOP_TEST_BASE.'owncloudclient-2.3.3-rc2.tar.xz';
-// The .tar.gz on github and our .tar.xz differ because of submodules etc!
-// $DOWNLOAD_CLIENT_DESKTOP_TEST_SOURCES = 'https://github.com/owncloud/client/archive/v2.3.3-rc1.tar.gz';
 $DOWNLOAD_CLIENT_DESKTOP_TEST_SOURCES_PGP = $DOWNLOAD_CLIENT_DESKTOP_TEST_SOURCES.'.asc';
 
 // Only used in https://owncloud.org/install/#testing-development


### PR DESCRIPTION
Push to staging after the packages are moved from testing to stable.
Do not push to live before official release announcements!

Test the fresh packages at https://download.owncloud.com/desktop/testing/?C=M;O=D

```
 testpilotcloud-2.3.3.8243.pkg.tbz.sig               2017-08-30 21:05   65   
[   ] testpilotcloud-2.3.3.8243.pkg.tbz                   2017-08-30 21:05   25M  
[   ] testpilotcloud-2.3.3.8243.pkg                       2017-08-30 21:05   25M  
[   ] testpilotcloud-2.3.3.8251-setup.exe                 2017-08-30 21:02   38M  
[TXT] testpilotcloud-client-2.3.3.8295.linux-repo.html    2017-08-30 21:01  969   
[   ] owncloudclient-2.3.3.tar.xz                         2017-08-30 20:58   32M  
[   ] ownCloud-2.3.3.8242.pkg.tbz.sig                     2017-08-30 20:55   65   
[   ] ownCloud-2.3.3.8242.pkg.tbz                         2017-08-30 20:55   26M  
[   ] ownCloud-2.3.3.8242.pkg                             2017-08-30 20:55   26M  
[   ] ownCloud-2.3.3.8250-setup.exe                       2017-08-30 20:52   38M  
[TXT] owncloud-client-2.3.3.8294.linux-repo.html          2017-08-30 20:49  940   
```