### PR TITLE
Nightly Testpilots to live, long and weird commit history

### DIFF
--- a/install-instructions.php
+++ b/install-instructions.php
@@ -391,7 +391,7 @@
         		  	</div>
 		  </div>
 		<div class="overlay-body row">
-		  <div class="col-md-12">
+		  <div class="col-md-offset-2 col-md-4">
                     <h2>Android Clients <small><?php echo $VERSIONS_CLIENT_ANDROID_TESTING; ?></small></h2>
                     <p>Our mobile team provides regular pre-releases. You can install them from the <a href="https://f-droid.org/packages/com.owncloud.android.beta/" target="_blank">F-Droid Android Appstore</a>. Please report any issues to the <a href="https://github.com/owncloud/android/issues" target="_blank">tracker</a>.</p>
 				    <div class="btn-group">

--- a/install-instructions.php
+++ b/install-instructions.php
@@ -380,7 +380,7 @@
 		    </div>
 		    <?php if(!empty($VERSIONS_CLIENT_DESKTOP_TESTING)) { ?>
         <h2>Testpilot Desktop Clients</h2>
- 		    <p>For those who prefer to install the test version next to the stable ownCloud version, we offer the "Testpilot" edition of the client, which will install in parallel to the original client:<br /><</p>
+ 		    <p>For those who prefer to install the test version next to the stable ownCloud version, we offer the "Testpilot" edition of the client, which will install in parallel to the original client:<br /></p>
 		    <div class="btn-group">
 		      <a href="<?php echo $DOWNLOAD_CLIENT_DESKTOP_TESTPILOT_WIN; ?>" class="btn btn-lg btn-default"><i class="icon-windows"></i>  Windows</a>
 		      <a href="<?php echo $DOWNLOAD_CLIENT_DESKTOP_TESTPILOT_MAC; ?>" class="btn btn-lg btn-default"><i class="icon-apple"></i> Mac</a>

--- a/install-instructions.php
+++ b/install-instructions.php
@@ -380,7 +380,7 @@
 		    </div>
 		    <?php if(!empty($VERSIONS_CLIENT_DESKTOP_TESTING)) { ?>
         <h2>Testpilot Desktop Clients</h2>
- 		    <p>For those who prefer to install the test version next to the stable ownCloud version, we offer the "Testpilot" edition of the client, which will install in parallel to the original client:<br /></p>
+ 		    <p>For those who prefer to install the test version next to the stable ownCloud version, we offer the "Testpilot" edition of the client, which will install in parallel to the original client:<br />&nbsp;</p>
 		    <div class="btn-group">
 		      <a href="<?php echo $DOWNLOAD_CLIENT_DESKTOP_TESTPILOT_WIN; ?>" class="btn btn-lg btn-default"><i class="icon-windows"></i>  Windows</a>
 		      <a href="<?php echo $DOWNLOAD_CLIENT_DESKTOP_TESTPILOT_MAC; ?>" class="btn btn-lg btn-default"><i class="icon-apple"></i> Mac</a>

--- a/install-instructions.php
+++ b/install-instructions.php
@@ -391,7 +391,7 @@
         		  	</div>
 		  </div>
 		<div class="overlay-body row">
-		  <div class="col-md-offset-4 col-md-6">
+		  <div class="col-md-offset-3 col-md-5">
                     <h2>Android Clients <small><?php echo $VERSIONS_CLIENT_ANDROID_TESTING; ?></small></h2>
                     <p>Our mobile team provides regular pre-releases. You can install them from the <a href="https://f-droid.org/packages/com.owncloud.android.beta/" target="_blank">F-Droid Android Appstore</a>. Please report any issues to the <a href="https://github.com/owncloud/android/issues" target="_blank">tracker</a>.</p>
 				    <div class="btn-group">

--- a/install-instructions.php
+++ b/install-instructions.php
@@ -389,8 +389,9 @@
 		    </div>
 		    <?php } else {?>
         <h2>Testpilot Desktop Clients</h2>
- 		    <p>For those who prefer to install the test version of the nightly client next to the stable ownCloud version, we offer the "Testpilot" edition of the client, which will install in parallel to the original client.
-			For Windows and Mac, just look for the most recent testpilot file in the directory.</p>
+ 		    <p>For those who prefer to install the test version of the nightly client next to the stable ownCloud version, we offer the "Testpilot" edition of the client. 
+          It will be installed next to the original client and does not interfere with it.
+          For Windows and Mac, just look for the most recent testpilot file in the directory.</p>
 		    <div class="btn-group">
 		      <a href="https://download.owncloud.com/desktop/daily/?C=M;O=D" class="btn btn-lg btn-default"><i class="icon-windows"></i>  Windows</a>
 		      <a href="https://download.owncloud.com/desktop/daily/?C=M;O=D" class="btn btn-lg btn-default"><i class="icon-apple"></i> Mac</a>

--- a/install-instructions.php
+++ b/install-instructions.php
@@ -391,7 +391,7 @@
         		  	</div>
 		  </div>
 		<div class="overlay-body row">
-		  <div class="col-md-offset-2 col-md-4">
+		  <div class="col-md-offset-4 col-md-6">
                     <h2>Android Clients <small><?php echo $VERSIONS_CLIENT_ANDROID_TESTING; ?></small></h2>
                     <p>Our mobile team provides regular pre-releases. You can install them from the <a href="https://f-droid.org/packages/com.owncloud.android.beta/" target="_blank">F-Droid Android Appstore</a>. Please report any issues to the <a href="https://github.com/owncloud/android/issues" target="_blank">tracker</a>.</p>
 				    <div class="btn-group">

--- a/page-agreement.php
+++ b/page-agreement.php
@@ -15,7 +15,7 @@ This thus helps pay the bills for ownCloud contributors.</p>
 We can accept your core contribution if you release your code under the MIT license. Of course we 
 recommend that you sign the agreement because AGPL/GPL protects the freedom of your work better than MIT. But the choice is yours.</p>
 <h3>How difficult is it to sign the agreement?</h3>
-<p>Very easy. When you submit your pull request you will prompted to sign the cla by clicking a button. We use <a href="https://cla-assistant.io/">cla-assistant.io</a> for this.
+<p>Very easy. When you submit your pull request you will prompted to sign the CLA by clicking a button. We use <a href="https://cla-assistant.io/">cla-assistant.io</a> for this.
 </p>
 <br />
 <h3>Is there any risk for me when I sign this agreement?</h3>

--- a/page-desktop.php
+++ b/page-desktop.php
@@ -17,8 +17,11 @@
 	<li>Windows: Fix a memory leak in FileSystem::longWinPath</li>
 	<li>Switch Linux build also to Qt 5.6.2 (<a href="https://github.com/owncloud/client/issues/5470">5470</a>)</li>
 	<li>Stopped maintaining Qt 4 buildability</li>
-        <li>Linux packaging fixes: install the owncloud-client-nemo, owncloud-client-nautilus, owncloud-client-caja, owncloud-client-dolphin package for sync-state icons and a share-with menu in your file manager.</li>
-        <li>Linux deprecation: Releases after 2.3.3 do not support Fedora_24 or lower, openSUSE_13.2 or lower, Debian_7.0 or lower.</li>
+  <li>Linux packaging fixes: install the owncloud-client-nemo, owncloud-client-nautilus, owncloud-client-caja, owncloud-client-dolphin package for sync-state icons and a share-with menu in your file manager.</li>
+  <li>Linux deprecation: Releases after 2.3.3 do not support Fedora 24 or lower, openSUSE Leap 42.1 or lower, Debian 7.0 or lower.</li>
+  <li>2.4.0 deprecation: No more 32-bit Linux support, no more MacOS X 10.9 support or lower.</li>
+  <li>Supported platforms are documented at <a href="https://doc.owncloud.org/server/latest/admin_manual/installation/system_requirements.html#desktop">Desktop System Requirements</a>.</li>
+  
 </ul>
 Download:
 <a href="https://download.owncloud.com/desktop/stable/ownCloud-2.3.3.8250-setup.exe">Windows</a> 

--- a/page-desktop.php
+++ b/page-desktop.php
@@ -24,12 +24,9 @@
   
 </ul>
 Download:
-<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.3.3.8250-setup.exe">Windows</a> 
-<a href="https://download.owncloud.com/desktop/stable/testpilotcloud-2.3.3.8251-setup.exe">(+)</a> |
-<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.3.3.8242.pkg">Mac</a>
-<a href="https://download.owncloud.com/desktop/stable/testpilotcloud-2.3.3.8243.pkg">(+)</a> | 
-<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> 
-<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:testpilot&amp;package=testpilotcloud-client">(+)</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.3.3.8250-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.3.3.8242.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> |
 <a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.3.3.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.3.3.tar.xz.asc">PGP signature</a>)
 
 

--- a/page-desktop.php
+++ b/page-desktop.php
@@ -3,7 +3,7 @@
 </div>
 
 <!-- When doing beta/rc vs release, always check the subdirectory name and the OBS repo name!! //-->
-<h3 id="233">Release 2.3.3 <small>August 28th 2017</small></h3>
+<h3 id="233">Release 2.3.3 <small>August 29th 2017</small></h3>
 <ul>
 	<li>Chunking NG: Don't use old chunking on new DAV endpoint (<a href="https://github.com/owncloud/client/issues/5855">5855</a>)</li>
 	<li>Selective Sync: Skip excluded folders when reading DB, don't let them show errors (<a href="https://github.com/owncloud/client/issues/5772">5772</a>)</li>
@@ -15,8 +15,8 @@
 	<li>SyncJournalDB: Don't use ._ as filename pattern if that does not work because of SMB storage settings (<a href="https://github.com/owncloud/client/issues/5844">5844</a>)</li>
 	<li>SyncJournalDB: Log reason for sqlite3 opening errors</li>
 	<li>Windows: Fix a memory leak in FileSystem::longWinPath</li>
-	<li>Switch Linux build also to Qt 5.6.2 (<a href="https://github.com/owncloud/client/issues/5470">5470</a>)</li>
-	<li>Stopped maintaining Qt 4 buildability</li>
+	<li>Switch Linux builds also to Qt 5.6.2 (<a href="https://github.com/owncloud/client/issues/5470">5470</a>)</li>
+	<li>Stopped maintaining Qt 4 support</li>
   <li>Linux packaging fixes: install the owncloud-client-nemo, owncloud-client-nautilus, owncloud-client-caja, owncloud-client-dolphin package for sync-state icons and a share-with menu in your file manager.</li>
   <li>Linux deprecation: Releases after 2.3.3 do not support Fedora 24 or lower, openSUSE Leap 42.1 or lower, Debian 7.0 or lower.</li>
   <li>2.4.0 deprecation: No more 32-bit Linux support, no more MacOS X 10.9 support or lower.</li>

--- a/page-desktop.php
+++ b/page-desktop.php
@@ -21,12 +21,12 @@
         <li>Linux deprecation: Releases after 2.3.3 do not support Fedora_24 or lower, openSUSE_13.2 or lower, Debian_7.0 or lower.</li>
 </ul>
 Download:
-<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.3.3.8250-setup.exe">Windows</a> |
-<a href="https://download.owncloud.com/desktop/stable/testpilotcloud-2.3.3.8251-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.3.3.8250-setup.exe">Windows</a> 
+<a href="https://download.owncloud.com/desktop/stable/testpilotcloud-2.3.3.8251-setup.exe">(+)</a> |
 <a href="https://download.owncloud.com/desktop/stable/ownCloud-2.3.3.8242.pkg">Mac</a> |
-<a href="https://download.owncloud.com/desktop/stable/testpilotcloud-2.3.3.8243.pkg">Mac</a> |
-<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> |
-<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:testpilot&amp;package=testpilotcloud-client">Linux</a> |
+<a href="https://download.owncloud.com/desktop/stable/testpilotcloud-2.3.3.8243.pkg">(+)</a> 
+<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> 
+<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:testpilot&amp;package=testpilotcloud-client">(+)</a> |
 <a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.3.3.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.3.3.tar.xz.asc">PGP signature</a>)
 
 

--- a/page-desktop.php
+++ b/page-desktop.php
@@ -19,7 +19,7 @@
 	<li>Stopped maintaining Qt 4 support</li>
   <li>Linux packaging fixes: install the owncloud-client-nemo, owncloud-client-nautilus, owncloud-client-caja, owncloud-client-dolphin package for sync-state icons and a share-with menu in your file manager.</li>
   <li>Linux deprecation: Releases after 2.3.3 do not support Fedora 24 or lower, openSUSE Leap 42.1 or lower, Debian 7.0 or lower.</li>
-  <li>2.4.0 deprecation: No more 32-bit Linux support, no more MacOS X 10.9 support or lower.</li>
+  <li>2.4.0 deprecation: We will drop 32-bit Linux support and MacOS X 10.9 support or lower.</li>
   <li>Supported platforms are documented at <a href="https://doc.owncloud.org/server/latest/admin_manual/installation/system_requirements.html#desktop">Desktop System Requirements</a>.</li>
   
 </ul>

--- a/page-desktop.php
+++ b/page-desktop.php
@@ -23,8 +23,8 @@
 Download:
 <a href="https://download.owncloud.com/desktop/stable/ownCloud-2.3.3.8250-setup.exe">Windows</a> 
 <a href="https://download.owncloud.com/desktop/stable/testpilotcloud-2.3.3.8251-setup.exe">(+)</a> |
-<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.3.3.8242.pkg">Mac</a> |
-<a href="https://download.owncloud.com/desktop/stable/testpilotcloud-2.3.3.8243.pkg">(+)</a> 
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.3.3.8242.pkg">Mac</a>
+<a href="https://download.owncloud.com/desktop/stable/testpilotcloud-2.3.3.8243.pkg">(+)</a> | 
 <a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> 
 <a href="https://software.opensuse.org/download/package?project=isv:ownCloud:testpilot&amp;package=testpilotcloud-client">(+)</a> |
 <a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.3.3.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.3.3.tar.xz.asc">PGP signature</a>)


### PR DESCRIPTION
Hi,

this pushes the nightly testpilots paragraph in https://staging.owncloud.org/install/#testing-development

in the commit history are more changes, but they appear to be there only because of a broken commit history. They will most likely not change anyhing.

If they do, may god save us.  
(aka then we need to revert the PR and rework some stuff)