### PR TITLE
added signatures & hashes to /install

### DIFF
--- a/install-instructions.php
+++ b/install-instructions.php
@@ -61,8 +61,8 @@
               <p class="installatlation-instructions"><strong>Installation Instructions:</strong></p>
               <ol class="install-steps">
                 <li>Download <a href="<?php echo $DOWNLOAD_SERVER_STABLE_TAR; ?>">.tar.bz2</a> or <a href="<?php echo $DOWNLOAD_SERVER_STABLE_ZIP; ?>">.zip</a> archive.</li>
-                <li>Check the <a href="<?php echo $DOWNLOAD_SERVER_STABLE_TAR_MD5; ?>">package integrity for your version </a>using MD5 (.tar.bz2 / .zip) or SHA256 (.tar.bz2 / .zip)</li>
-                <li>Verify the authenticity via PGP (.tar.bz2 /.zip). The ownCloud GPG key is <a target="_blank" href="<?php echo $OWNCLOUD_GPG ; ?>">here</a>.</li>
+                <li>Check the <a href="/changelog">package integrity for your version </a>using MD5 (<a href="<?php echo $DOWNLOAD_SERVER_STABLE_TAR_MD5; ?>">.tar.bz2</a> / <a href="<?php echo $DOWNLOAD_SERVER_STABLE_ZIP_MD5; ?>">.zip</a>) or SHA256 (<a href="<?php echo $DOWNLOAD_SERVER_STABLE_TAR_SHA256;?>">.tar.bz2</a> / <a href="<?php echo $DOWNLOAD_SERVER_STABLE_ZIP_SHA256; ?>">.zip</a>)</li>
+                <li>Verify the authenticity via PGP (<a href="<?php echo $DOWNLOAD_SERVER_STABLE_TAR_PGP; ?>">.tar.bz2</a> / <a href="<?php echo $DOWNLOAD_SERVER_STABLE_ZIP_PGP; ?>">.zip</a>). The ownCloud GPG key is <a target="_blank" href="<?php echo $OWNCLOUD_GPG ; ?>">here</a>.</li>
                 <li>Follow the <a href="<?php echo $DOCUMENTATION_ADMIN; ?>installation">ownCloud Admin Manuals’</a> installation chapter. If you already run ownCloud, refer to the <a href="<?php echo $DOCUMENTATION_ADMIN; ?>maintenance/update.html">update documentation</a> for minor releases and the <a href="<?php echo $DOCUMENTATION_ADMIN; ?>maintenance/upgrade.html">upgrade manual</a> for moving to major new ownCloud releases.</li>
               </ol>
             </div>


### PR DESCRIPTION
In https://github.com/owncloud/documentation/issues/3459 @voroyam pointed out that https://owncloud.org/install/#edition only links to the changelog and not to each single md5 signature.

I linked to all of the signatures with their fitting variables.